### PR TITLE
Add generic interface for conditionally halting the interpreter

### DIFF
--- a/cranefack/src/errors.rs
+++ b/cranefack/src/errors.rs
@@ -99,6 +99,11 @@ impl CraneFackError for ParserError {
 /// Runtime errors for interpreter invocations
 #[derive(Debug)]
 pub enum RuntimeError {
+    /// The interpreter's configured [`Limiter`][crate::limiters::Limiter] triggered
+    LimiterTriggered {
+        span: Range<usize>,
+    },
+
     /// The program tries to use a heap cell beyond the maximu allowed size
     MaxHeapSizeReached {
         span: Range<usize>,
@@ -125,6 +130,7 @@ impl Error for RuntimeError {
 impl Display for RuntimeError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
+            RuntimeError::LimiterTriggered { .. } => write!(f, "Max number of cycles reached"),
             RuntimeError::MaxHeapSizeReached {
                 max_heap_size,
                 required,
@@ -142,6 +148,7 @@ impl Display for RuntimeError {
 impl CraneFackError for RuntimeError {
     fn get_message(&self) -> (Option<Range<usize>>, String, Option<String>) {
         match self {
+            RuntimeError::LimiterTriggered { span } => (Some(span.clone()), self.to_string(), None),
             RuntimeError::MaxHeapSizeReached { span, .. } => {
                 (Some(span.clone()), self.to_string(), None)
             }

--- a/cranefack/src/lib.rs
+++ b/cranefack/src/lib.rs
@@ -55,6 +55,7 @@ mod analyzer;
 mod backends;
 mod errors;
 mod ir;
+pub mod limiters;
 mod optimizations;
 mod parser;
 

--- a/cranefack/src/limiters.rs
+++ b/cranefack/src/limiters.rs
@@ -1,0 +1,66 @@
+pub enum LimiterResult {
+    /// Continue executing
+    Continue,
+    /// Halt execution and return [`LimiterTriggered`][crate::errors::RuntimeError::LimiterTriggered]
+    Halt,
+}
+
+/// Generic interface for determining whether to continue or stop execution.
+pub trait Limiter {
+    fn execute_op(&mut self) -> LimiterResult;
+}
+
+/// Always returns [`Continue`][LimiterResult::Continue].
+pub struct Unlimited;
+
+impl Limiter for Unlimited {
+    fn execute_op(&mut self) -> LimiterResult {
+        LimiterResult::Continue
+    }
+}
+
+/// Limit execution to within the configured number of cycles.
+pub struct CycleLimiter(usize);
+
+impl CycleLimiter {
+    pub fn new(max_cycles: usize) -> Self {
+        CycleLimiter(max_cycles)
+    }
+}
+
+impl Limiter for CycleLimiter {
+    fn execute_op(&mut self) -> LimiterResult {
+        self.0 = self.0.saturating_sub(1);
+        if self.0 == 0 {
+            LimiterResult::Halt
+        } else {
+            LimiterResult::Continue
+        }
+    }
+}
+
+/// Limits execution to within a given [`Duration`](std::time::Duration) of time.
+pub struct TimeLimiter {
+    max_duration: std::time::Duration,
+    started_at: Option<std::time::Instant>,
+}
+
+impl TimeLimiter {
+    pub fn new(max_duration: std::time::Duration) -> Self {
+        TimeLimiter {
+            max_duration,
+            started_at: None,
+        }
+    }
+}
+
+impl Limiter for TimeLimiter {
+    fn execute_op(&mut self) -> LimiterResult {
+        let started_at = self.started_at.get_or_insert(std::time::Instant::now());
+        if started_at.elapsed() > self.max_duration {
+            LimiterResult::Halt
+        } else {
+            LimiterResult::Continue
+        }
+    }
+}


### PR DESCRIPTION
I was considering that it might sometimes be useful to get the actual op executed as well, but since those structs aren't public and I don't actually have a need for that right now I decided to skip that.